### PR TITLE
Ability to use custom mappings and ditch default ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ By default, the following mappings are enabled :
 * *C-g* sends the current cell to tmux
 * *C-b* sends the current cell to tmux, moving to the next one
 
+You can disable default mappings :
+
+    let g:cellmode_default_mappings='0'
+
 In addition, there is a function to execute all cells above the current line
 which isn't bound by default, but you can easily bind it with :
 

--- a/doc/cellmode.txt
+++ b/doc/cellmode.txt
@@ -64,6 +64,10 @@ By default, the following mappings are enabled :
   C-g sends the current cell to tmux
   C-b sends the current cell to tmux, moving to the next one
 
+You can disable default mappings :
+
+    let g:cellmode_default_mappings='0'
+
 In addition, there is a function to execute all cells above the current line
 which isn't bound by default, but you can easily bind it with :
 

--- a/ftplugin/python/cellmode.vim
+++ b/ftplugin/python/cellmode.vim
@@ -248,6 +248,20 @@ function! RunTmuxPythonChunk() range
   call RunTmuxPythonReg()
 endfunction
 
-vmap <silent> <C-c> :call RunTmuxPythonChunk()<CR>
-noremap <silent> <C-b> :call RunTmuxPythonCell(0)<CR>
-noremap <silent> <C-g> :call RunTmuxPythonCell(1)<CR>
+" Returns:
+"   1 if the var is set, 0 otherwise
+function s:InitVariable(var, value)
+    if !exists(a:var)
+        execute 'let ' . a:var . ' = ' . "'" . a:value . "'"
+        return 1
+    endif
+    return 0
+endfunction
+
+call s:InitVariable("g:cellmode_default_mappings", 1)
+
+if g:cellmode_default_mappings
+    vmap <silent> <C-c> :call RunTmuxPythonChunk()<CR>
+    noremap <silent> <C-b> :call RunTmuxPythonCell(0)<CR>
+    noremap <silent> <C-g> :call RunTmuxPythonCell(1)<CR>
+endif


### PR DESCRIPTION
Users often want to add custom mappings to plugin functions, for example my config is:

```
       " Custom plugin mappings
        vnoremap <leader>pp :call RunTmuxPythonChunk()<CR>
        nnoremap <leader>pp :call RunTmuxPythonCell(0)<CR>
        noremap <leader>pa :call RunTmuxPythonAllCellsAbove()<CR><CR>

        " Don't use default mappings -> Added functionality
         let g:cellmode_default_mappings='0'
```

Thanks for this great plugin!
